### PR TITLE
General improvements

### DIFF
--- a/uniprot_pdb_mapper.py
+++ b/uniprot_pdb_mapper.py
@@ -116,9 +116,10 @@ def main():
     parser = argparse.ArgumentParser(description="Residue and Chain Mapper for UniProt and PDB.")
     parser.add_argument("-u", "--uniprot-id", required=True, 
                         help="The UniProt ID of the protein.")
-    parser.add_argument("-p", "--pdb-id", 
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("-p", "--pdb-id", default=None, 
                         help="The PDB ID of the structure to map (optional).")
-    parser.add_argument("--list-all", action="store_true",
+    group.add_argument("-l", "--list-all", action="store_true",
                         help="List all PDB entries mapped to the UniProt ID with metadata.")
     parser.add_argument("-o", "--outfile", default=None,
                         help="File to write results in .json")

--- a/uniprot_pdb_mapper.py
+++ b/uniprot_pdb_mapper.py
@@ -58,7 +58,7 @@ def fetch_biological_assembly(pdb_id):
         assembly_data = response.json().get(pdb_id, [{}])[0].get('assemblies', [])
         if not assembly_data:
             raise ValueError(f"No biological assembly found for PDB ID: {pdb_id}")
-        return next((assembly for assembly in assembly_data if assembly["preferred"] == True), assembly_data[0])
+        return next((assembly for assembly in assembly_data if assembly["preferred"]), assembly_data[0])
     else:
         raise ValueError(f"Failed to fetch biological assembly for PDB ID: {pdb_id}")
 

--- a/uniprot_pdb_mapper.py
+++ b/uniprot_pdb_mapper.py
@@ -172,6 +172,7 @@ def main():
 
         elif pdb_id:
             # Mode: UniProt ID and PDB ID provided
+            pdb_id = pdb_id.lower()
             print(f"Mapping residues for UniProt ID: {uniprot_id} and PDB ID: {pdb_id}.", file=sys.stderr)
             assembly = fetch_biological_assembly(pdb_id)
             assembly_id = int(assembly["assembly_id"])


### PR DESCRIPTION
- Make '--pdb-id' and '--list-all' flags mutually exclusive & add '-l' short-hand option to '--list-all'
- 'fetch_biological_assembly' and 'map_residues' functions fail when '--pdb-id' is uppercase as per the README.md (i.e '1BZ0' gives an error, '1bz0' does not). Add '.lower()' method to fix this issue